### PR TITLE
Update URLs in package.json to point to correct repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tosdr-firefox",
+  "name": "tosdr-browser-extension",
   "version": "1.0.0",
   "description": "“I have read and agree to the Terms” is the biggest lie on the web. We aim to fix that. “Terms of Service; Didn't Read” is a user rights initiative to rate and label website terms & privacy policies, from very good (class A) to very bad (class E).",
   "main": "mixin.js",
@@ -19,12 +19,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tosdr/tosdr-firefox.git"
+    "url": "git+https://github.com/tosdr/browser-extensions.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/tosdr/tosdr-firefox/issues"
+    "url": "https://github.com/tosdr/browser-extensions/issues"
   },
-  "homepage": "https://github.com/tosdr/tosdr-firefox#readme"
+  "homepage": "https://github.com/tosdr/browser-extensions#readme"
 }


### PR DESCRIPTION
Some URLs were probably forgotten from the move between repositories from `tosdr-firefox` to `browser-extensions`. This patch updates those links in `package.json` and gives the package an updated name.