### PR TITLE
Allow people to bypass templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Report a Bug
     url: https://tosdr.org/en/downloads#bug


### PR DESCRIPTION
The current urls to bug reports vand feature requests don't seem to work correctly. 