### PR TITLE
Make the last updated in settings correspond to the user's language

### DIFF
--- a/src/scripts/views/settings/state.ts
+++ b/src/scripts/views/settings/state.ts
@@ -18,7 +18,7 @@ export async function populateSettingsForm(): Promise<void> {
     if (Array.isArray(result['db'])) {
         const lastModified = new Date(String(result['lastModified']));
         if (!Number.isNaN(lastModified.getTime()) && elements.date) {
-            elements.date.textContent = lastModified.toLocaleDateString('en-US');
+            elements.date.textContent = lastModified.toLocaleDateString();
         }
         if (elements.indexed) {
             elements.indexed.textContent = String(result['db'].length);


### PR DESCRIPTION
Does what it says on the tin really. Makes it so that the "last updated" reflects the user's system date settings, instead of defaulting to MM/DD/YYYY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated date display in settings to respect your system's locale preferences instead of using a fixed format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->